### PR TITLE
1주차 풀이 업데이트

### DIFF
--- a/01/joy.js
+++ b/01/joy.js
@@ -23,7 +23,7 @@ function solution(users, emoticons) {
   const discountRateEnumContextList = permutation(4, emoticons.length);
   let [plusEnter, salesAmount] = [0, 0];
 
-  discountRateEnumContextList.map((discountRateEnumContext, idx) => {
+  discountRateEnumContextList.forEach((discountRateEnumContext) => {
     let [_plusEnter, _salesAmount] = [0, 0];
 
     users.forEach(([비율, 최대가격]) => {
@@ -53,7 +53,10 @@ function solution(users, emoticons) {
   return [plusEnter, salesAmount];
 }
 
-// 중복 순열 DFS
+/*
+  중복 순열 DFS
+  @reference https://velog.io/@rladpwl0512/8-8-%EC%A4%91%EB%B3%B5%EC%88%9C%EC%97%B4-%EA%B5%AC%ED%95%98%EA%B8%B0
+*/
 function permutation(n, m) {
   let answer = [];
   let tmp = Array.from({ length: m }, () => 0);
@@ -72,5 +75,3 @@ function permutation(n, m) {
   DFS(0);
   return answer;
 }
-
-// permutation(3, 2);

--- a/01/joy.js
+++ b/01/joy.js
@@ -1,0 +1,76 @@
+/*
+1.이모티콘 길이만큼 할일률 리스트업 
+  [[ 이모티콘 길이 ], [ 이모티콘 길이 ], ...]
+  e.g. 길이: 4^(이모티콘 길이) (최대 7)
+    [[0.1, 0.1, 0.1], [0.1, 0.1, 0.2], ...]
+    
+result = [plusEnterCount, discountAmmount]
+2. 1번 루프돌면서
+  루프마다 (A)
+    user 루프 (B) [비율, 가격]
+      plusEnterCount 
+      discountAmmount
+      A 루프 
+        if(비율 <= A[i]) 할인 적용
+        else count++
+      
+      plusEnterCount 기준 result Max 갱신
+        plusEnterCount 
+        discountAmmount
+*/
+
+function solution(users, emoticons) {
+  const discountRateEnumContextList = permutation(4, emoticons.length);
+  let [plusEnter, salesAmount] = [0, 0];
+
+  discountRateEnumContextList.map((discountRateEnumContext, idx) => {
+    let [_plusEnter, _salesAmount] = [0, 0];
+
+    users.forEach(([비율, 최대가격]) => {
+      let sumAmount = 0;
+
+      discountRateEnumContext.forEach((discountRateEnum, index) => {
+        const 비교할인백분률 = discountRateEnum * 10;
+        if (비율 > 비교할인백분률) return;
+
+        const 적용백분률 = 100 - 비교할인백분률;
+        sumAmount += (emoticons[index] * 적용백분률) / 100;
+      });
+
+      if (sumAmount >= 최대가격) _plusEnter += 1;
+      else _salesAmount += sumAmount;
+    });
+
+    if (plusEnter > _plusEnter) return;
+    if (plusEnter < _plusEnter) {
+      plusEnter = _plusEnter;
+      salesAmount = _salesAmount;
+      return;
+    }
+    if (salesAmount < _salesAmount) salesAmount = _salesAmount;
+  });
+
+  return [plusEnter, salesAmount];
+}
+
+// 중복 순열 DFS
+function permutation(n, m) {
+  let answer = [];
+  let tmp = Array.from({ length: m }, () => 0);
+
+  function DFS(L) {
+    if (L === m) {
+      answer.push(tmp.slice());
+    } else {
+      for (let i = 1; i <= n; i++) {
+        tmp[L] = i;
+        DFS(L + 1);
+      }
+    }
+  }
+
+  DFS(0);
+  return answer;
+}
+
+// permutation(3, 2);


### PR DESCRIPTION
### Summary

- [문제 링크](https://school.programmers.co.kr/learn/courses/30/lessons/150368?language=javascript)
- 시간복잡도: O(n)

### 문제 풀이 설명
1. 할인의 케이스별로 컨텍스트를 만들어둔다. 
  - 2차배열로 추상화
  - 하나의 컨텍스트에는 이모티콘의 갯수만큼, 할인 케이스를 나열한다. -> 중복순열
2. 컨텍스트를 loop하며 유저별로 조건을 확인한다.
  1. 이모티콘 가격별로 할인 케이스 합산을 산출
  2. 산출된 합산과 비교 하여 플러스 가입 or 매출로 전환
  3. 컨텍스트별로 memoize했던 플러스 가입카운트, 매출 양을 비교 (우선순위가 있으므로 가입카운트부터 진행)




```
// 수도코드
```

### 고민 포인트
- 루프가 3번이나 중첩되어있다. 
- 2-1에서 전체 합산이 아니더라도 중간에 조건 이하이면 loop를 중단해도 되지 않을까 싶다.

### 리뷰어 Check-list

- [x] 가독성이 괜찮나요?
- [ ] 엣지케이스를 대응하였나요?
